### PR TITLE
pySMESH support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,13 @@ docs/build/
 __pycache__/
 *.py[co]
 
+# Kdevelop
+.kdev4/
+*.kdev4
+
+*.egg-info
+
 generate/
 test/output/
+test/build/
 log.txt

--- a/pybinder/core.py
+++ b/pybinder/core.py
@@ -587,7 +587,6 @@ class Generator(object):
         logger.write('Traversing...\n')
         # Traverse the translation unit and group the binders into modules
         binders = self.tu_binder.get_children()
-        ignored = set()
         for binder in binders:
             # Only bind definitions
             # TODO Why is IGESFile and StepFile not considered definitions?
@@ -611,17 +610,11 @@ class Generator(object):
             # Add binder only if it's in an OCCT header file.
             inc = binder.filename
             if inc not in available_incs:
-                if inc not in ignored:
-                    ignored.add(inc)
-                    msg = '\tSkipping include {}.\n'.format(inc)
-                    logger.write(msg)
                 continue
 
             # Add binder if it's in an available module
             mod_name = binder.module_name
             if mod_name not in Generator.available_mods:
-                msg = '\tIgnoring mod {}.\n'.format(mod_name)
-                logger.write(msg)
                 continue
 
             # Add to module
@@ -1755,8 +1748,8 @@ class CursorBinder(object):
     @property
     def parameter_signature(self):
         """
-        Return the text of the paramter exluding the name
-        :return: parameter spelling
+        Return the text of the paramter excluding the name
+        :return: The parameter spelling
         :rtype: str
 
         """

--- a/pybinder/core.py
+++ b/pybinder/core.py
@@ -129,6 +129,7 @@ class Generator(object):
     _mods = OrderedDict()
 
     def __init__(self, package_name, namespace, all_includes, main_includes):
+        self.package_name = package_name
         self._indx = Index.create()
 
         # Primary include directories

--- a/pybinder/core.py
+++ b/pybinder/core.py
@@ -94,11 +94,10 @@ class Generator(object):
 
     package_name = 'OCCT'
 
-    common_includes = set(['pyOCCT_Common.hxx'])
-
     available_mods = set()
     namespace = dict()
     available_incs = set()
+    common_includes = set()
     available_templates = set()
     excluded_classes = set()
     excluded_functions = set()

--- a/pybinder/core.py
+++ b/pybinder/core.py
@@ -1747,7 +1747,7 @@ class CursorBinder(object):
     @property
     def parameter_signature(self):
         """
-        Return the text of the paramter excluding the name
+        Return the text of the parameter excluding the name
         :return: The parameter spelling
         :rtype: str
 

--- a/pybinder/core.py
+++ b/pybinder/core.py
@@ -638,6 +638,10 @@ class Generator(object):
                 logger.write(msg)
                 continue
 
+            # Check for anon/untagged enum
+            if not qname and binder.is_enum:
+                qname = binder.type.spelling
+
             if not qname:
                 msg = '\tNo qualified name. Skipping {}.\n'.format(
                     binder.type.spelling

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+
+# set the project name
+project(pyBinderTest)
+
+message(STATUS "Searching for Python and pybind11...")
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
+
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+# Add pybind11 module
+pybind11_add_module(pyBinderTest output/Test.cxx)
+target_link_libraries(pyBinderTest PUBLIC ${Python_LIBRARIES})

--- a/test/all_includes.h
+++ b/test/all_includes.h
@@ -1,3 +1,4 @@
 #include <Test_Class.h>
+#include <Test_Enum.h>
 #include <Test_Params.h>
 #include <Test_Template.h>

--- a/test/all_includes.h
+++ b/test/all_includes.h
@@ -1,2 +1,3 @@
 #include <Test_Class.h>
+#include <Test_Params.h>
 #include <Test_Template.h>

--- a/test/environment.yml
+++ b/test/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - python-clang
   - pybind11
   - cmake
+  - ninja

--- a/test/environment.yml
+++ b/test/environment.yml
@@ -5,3 +5,5 @@ dependencies:
   - python=3.7
   - clangdev
   - python-clang
+  - pybind11
+  - cmake

--- a/test/expected/Test.cxx
+++ b/test/expected/Test.cxx
@@ -19,7 +19,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
-#include <pyOCCT_Common.hxx>
+#include <pyTest_Common.hxx>
 #include <Test_Class.h>
 
 PYBIND11_MODULE(Test, mod) {

--- a/test/expected/Test.cxx
+++ b/test/expected/Test.cxx
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include <pyTest_Common.hxx>
 #include <Test_Class.h>
+#include <Test_Params.h>
 
 PYBIND11_MODULE(Test, mod) {
 
@@ -43,6 +44,22 @@ cls_Test_SimpleClass.def("TestReturnPolicy3", (int & (Test_SimpleClass::*)()) &T
 // After type
 // Testing +after_type line 1
 // Testing +after_type line 2
+
+// CLASS: TEST_ITEM
+py::class_<Test_Item> cls_Test_Item(mod, "Test_Item", "None");
+
+// Constructors
+cls_Test_Item.def(py::init<>());
+
+// CLASS: TEST_PARAMS
+py::class_<Test_Params> cls_Test_Params(mod, "Test_Params", "None");
+
+// Constructors
+cls_Test_Params.def(py::init<>());
+
+// Methods
+cls_Test_Params.def("AddItems", (void (Test_Params::*)(const std::vector<const Test_Item *> &) const) &Test_Params::AddItems, "None", py::arg("items"));
+cls_Test_Params.def("AddItems", (void (Test_Params::*)(const std::vector<const Test_Item *> &, const std::vector<int> &) const) &Test_Params::AddItems, "None", py::arg("items"), py::arg("indices"));
 
 
 }

--- a/test/expected/Test.cxx
+++ b/test/expected/Test.cxx
@@ -20,10 +20,21 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include <pyTest_Common.hxx>
+#include <Test_Enum.h>
 #include <Test_Class.h>
 #include <Test_Params.h>
 
 PYBIND11_MODULE(Test, mod) {
+
+
+// ENUM: 
+py::enum_<TaggedEnum>(mod, "TaggedEnum", "None")
+	.value("TaggedEnum_A", TaggedEnum::TaggedEnum_A)
+	.value("TaggedEnum_B", TaggedEnum::TaggedEnum_B)
+	.export_values();
+
+mod.attr("UnTaggedEnum_A") = py::cast(int(UnTaggedEnum_A));
+mod.attr("UnTaggedEnum_B") = py::cast(int(UnTaggedEnum_B));
 
 
 // CLASS: TEST_SIMPLECLASS
@@ -44,6 +55,10 @@ cls_Test_SimpleClass.def("TestReturnPolicy3", (int & (Test_SimpleClass::*)()) &T
 // After type
 // Testing +after_type line 1
 // Testing +after_type line 2
+
+// TYPEDEF: TAGGEDENUM
+
+// TYPEDEF: UNTAGGEDENUM
 
 // CLASS: TEST_ITEM
 py::class_<Test_Item> cls_Test_Item(mod, "Test_Item", "None");

--- a/test/include/Test_Enum.h
+++ b/test/include/Test_Enum.h
@@ -1,0 +1,12 @@
+
+typedef enum {
+    TaggedEnum_A = 0,
+    TaggedEnum_B = 1,
+} TaggedEnum;
+
+
+typedef int UnTaggedEnum;
+enum {
+    UnTaggedEnum_A = 0,
+    UnTaggedEnum_B = 1,
+}; // No name

--- a/test/include/Test_Params.h
+++ b/test/include/Test_Params.h
@@ -1,0 +1,18 @@
+#include <vector>
+
+class Test_Item
+{
+public:
+        Test_Item();
+};
+
+class Test_Params
+{
+public:
+
+    Test_Params();
+
+    void AddItems(const std::vector<const Test_Item*>& items) const {};
+    void AddItems(const std::vector<const Test_Item*>& items, const std::vector<int>& indices) const {};
+
+};

--- a/test/include/Test_Template.h
+++ b/test/include/Test_Template.h
@@ -4,6 +4,7 @@ class Test_Template
 {
 public:
 
-    Test_Template<T>();
+    Test_Template<T, K>();
 
 };
+

--- a/test/include/pyTest_Common.hxx
+++ b/test/include/pyTest_Common.hxx
@@ -1,0 +1,5 @@
+#pragma once
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+namespace py = pybind11;

--- a/test/test_pybinder.py
+++ b/test/test_pybinder.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+import os
 import unittest
 
 from pybinder.core import Generator
@@ -33,9 +34,10 @@ class TestBinder(unittest.TestCase):
         Set up the tests by parsing the header.
         """
         available_mods = {'Test'}
-        inc = './include/'
+        all_includes = os.listdir('./include/')
+        main_includes = set()
         output_path = './output'
-        gen = Generator(available_mods, inc)
+        gen = Generator('Test', {'Test': available_mods}, all_includes, main_includes)
         gen.process_config('config.txt')
         gen.parse('all_includes.h')
         gen.dump_diagnostics(1)

--- a/test/test_pybinder.py
+++ b/test/test_pybinder.py
@@ -18,9 +18,22 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 import os
+import sys
+import shutil
 import unittest
+import subprocess
 
 from pybinder.core import Generator
+
+
+def run(*args, **kwargs):
+    """
+    Run a command and print the output
+    """
+    output = subprocess.check_output(*args, **kwargs).decode()
+    for line in output.split('\n'):
+        print(line)
+    return output
 
 
 class TestBinder(unittest.TestCase):
@@ -55,6 +68,15 @@ class TestBinder(unittest.TestCase):
                 with open(f'expected/{filename}') as f2:
                     for l1, l2 in zip(f1, f2):
                         self.assertEqual(l1, l2)
+
+    def test_compile(self):
+        shutil.rmtree('build', ignore_errors=True)
+        os.makedirs('build')
+        output = run('cmake ../'.split(), cwd='build')
+        self.assertIn('Configuring done', output)
+        self.assertIn('Generating done', output)
+        output = run('make', cwd='build')
+        self.assertIn('Built target pyBinderTest', output)
 
 
 if __name__ == '__main__':

--- a/test/test_pybinder.py
+++ b/test/test_pybinder.py
@@ -72,10 +72,14 @@ class TestBinder(unittest.TestCase):
     def test_compile(self):
         shutil.rmtree('build', ignore_errors=True)
         os.makedirs('build')
-        output = run('cmake ../ -G Ninja'.split(), cwd='build')
+        args = []
+        if sys.platform == 'win32':
+            prefix = os.environ.get("LIBRARY_PREFIX", '')
+            args.append('-DCMAKE_SYSTEM_PREFIX_PATH=%s' % prefix)
+        output = run('cmake ../ -G Ninja'.split() + args, cwd='build')
         self.assertIn('Configuring done', output)
         self.assertIn('Generating done', output)
-        output = run('ninja install'.split(), cwd='build')
+        output = run('ninja'.split(), cwd='build')
         self.assertIn('Building', output)
         self.assertIn('Linking', output)
 

--- a/test/test_pybinder.py
+++ b/test/test_pybinder.py
@@ -72,11 +72,12 @@ class TestBinder(unittest.TestCase):
     def test_compile(self):
         shutil.rmtree('build', ignore_errors=True)
         os.makedirs('build')
-        output = run('cmake ../'.split(), cwd='build')
+        output = run('cmake ../ -G Ninja'.split(), cwd='build')
         self.assertIn('Configuring done', output)
         self.assertIn('Generating done', output)
-        output = run('make', cwd='build')
-        self.assertIn('Built target pyBinderTest', output)
+        output = run('ninja install'.split(), cwd='build')
+        self.assertIn('Building', output)
+        self.assertIn('Linking', output)
 
 
 if __name__ == '__main__':

--- a/test/test_pybinder.py
+++ b/test/test_pybinder.py
@@ -35,7 +35,7 @@ class TestBinder(unittest.TestCase):
         """
         available_mods = {'Test'}
         all_includes = os.listdir('./include/')
-        main_includes = set()
+        main_includes = ['./include/']
         output_path = './output'
         gen = Generator('Test', {'Test': available_mods}, all_includes, main_includes)
         gen.process_config('config.txt')

--- a/test/test_pybinder.py
+++ b/test/test_pybinder.py
@@ -76,6 +76,7 @@ class TestBinder(unittest.TestCase):
         if sys.platform == 'win32':
             prefix = os.environ.get("LIBRARY_PREFIX", '')
             args.append('-DCMAKE_SYSTEM_PREFIX_PATH=%s' % prefix)
+            print(args)
         output = run('cmake ../ -G Ninja'.split() + args, cwd='build')
         self.assertIn('Configuring done', output)
         self.assertIn('Generating done', output)


### PR DESCRIPTION
This adds changes to support for generating bindings for pySMESH. The `pyOCCT` binder/run.py will need updated as this changes the `Generator` parameters. 

Summary of changes:
- Changed interface to pass `all_includes` and `main_includes` as parameters since occt and smesh use different directory structures
- Added a namespace field which is a dict of mods by package name that can be imported from other packages (so the binder can automatically add imports from OCCT when building SMESH)
- Added a `parameter_signature` which pulls the source text of parameters. This fixes some errors where pybind couldn't convert ~~`const int&` for `const std::vector<SMESH_...*>&`~~ parameters Edit: Seems to be related to overloaded parameters 
- Implemented support to exclude which modules are built (I'm not sure if that worked before?)

Also new PR for pySMESH incoming... 