### PR TITLE
Include enums with no qname

### DIFF
--- a/pybinder/core.py
+++ b/pybinder/core.py
@@ -625,6 +625,10 @@ class Generator(object):
                 logger.write(msg)
                 continue
 
+            # Check for anon/untagged enum
+            if not qname and binder.is_enum:
+                qname = binder.type.spelling
+
             if not qname:
                 msg = '\tNo qualified name. Skipping {}.\n'.format(
                     binder.type.spelling

--- a/test/all_includes.h
+++ b/test/all_includes.h
@@ -1,2 +1,3 @@
 #include <Test_Class.h>
+#include <Test_Enum.h>
 #include <Test_Template.h>

--- a/test/expected/Test.cxx
+++ b/test/expected/Test.cxx
@@ -20,9 +20,20 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include <pyOCCT_Common.hxx>
+#include <Test_Enum.h>
 #include <Test_Class.h>
 
 PYBIND11_MODULE(Test, mod) {
+
+
+// ENUM: 
+py::enum_<TaggedEnum>(mod, "TaggedEnum", "None")
+	.value("TaggedEnum_A", TaggedEnum::TaggedEnum_A)
+	.value("TaggedEnum_B", TaggedEnum::TaggedEnum_B)
+	.export_values();
+
+mod.attr("UnTaggedEnum_A") = py::cast(int(UnTaggedEnum_A));
+mod.attr("UnTaggedEnum_B") = py::cast(int(UnTaggedEnum_B));
 
 
 // CLASS: TEST_SIMPLECLASS
@@ -43,6 +54,10 @@ cls_Test_SimpleClass.def("TestReturnPolicy3", (int & (Test_SimpleClass::*)()) &T
 // After type
 // Testing +after_type line 1
 // Testing +after_type line 2
+
+// TYPEDEF: TAGGEDENUM
+
+// TYPEDEF: UNTAGGEDENUM
 
 
 }

--- a/test/include/Test_Enum.h
+++ b/test/include/Test_Enum.h
@@ -1,0 +1,12 @@
+
+typedef enum {
+    TaggedEnum_A = 0,
+    TaggedEnum_B = 1,
+} TaggedEnum;
+
+
+typedef int UnTaggedEnum;
+enum {
+    UnTaggedEnum_A = 0,
+    UnTaggedEnum_B = 1,
+}; // No name


### PR DESCRIPTION
Cherry picked from #21 to fix some missing enums in pyOCCT.