### PR TITLE
Add ability to set keep_alive

### DIFF
--- a/pybinder/core.py
+++ b/pybinder/core.py
@@ -118,6 +118,7 @@ class Generator(object):
     python_names = dict()
     excluded_imports = dict()
     call_guards = dict()
+    keep_alive = dict()
     before_type = dict()
     after_type = dict()
     patches = dict()
@@ -380,6 +381,14 @@ class Generator(object):
                         self.call_guards[qname].append(txt)
                     else:
                         self.call_guards[qname] = [txt]
+                    continue
+
+                # Keep alive
+                if line.startswith('+keep_alive'):
+                    line = line.replace('+keep_alive', '')
+                    line = line.strip()
+                    qname, params = line.split('-->', 1)
+                    self.keep_alive[qname.strip()] = params.strip()
                     continue
 
                 # Nested classes
@@ -2669,6 +2678,10 @@ def generate_method(binder):
     if qname in Generator.return_policies:
         return_policy = ', py::return_value_policy::{}'.format(Generator.return_policies[qname])
 
+    keep_alive = ''
+    if qname in Generator.keep_alive:
+        keep_alive = ', py::keep_alive<{}>()'.format(Generator.keep_alive[qname])
+
     # Call guards
     cguards = ''
     if qname in Generator.call_guards:
@@ -2700,12 +2713,12 @@ def generate_method(binder):
                 py_args.append(', py::arg(\"{}\")'.format(name))
             py_args = ''.join(py_args)
 
-            src = '{}.def{}(\"{}\", ({} ({})({}){}) &{}, {}\"{}\"{}{}{});\n'.format(
+            src = '{}.def{}(\"{}\", ({} ({})({}){}) &{}, {}\"{}\"{}{}{}{});\n'.format(
                 prefix, is_static,
                 fname, rtype, ptr,
                 signature, is_const,
                 qname, is_operator,
-                docs, py_args, return_policy, cguards)
+                docs, py_args, return_policy, keep_alive, cguards)
         else:
             arg_list = []
             args_spelling = []

--- a/test/all_includes.h
+++ b/test/all_includes.h
@@ -1,3 +1,4 @@
 #include <Test_Class.h>
 #include <Test_Enum.h>
+#include <Test_KeepAlive.h>
 #include <Test_Template.h>

--- a/test/config.txt
+++ b/test/config.txt
@@ -20,3 +20,6 @@
 # After type
 +after_type Test_SimpleClass-->// Testing +after_type line 1
 +after_type Test_SimpleClass-->// Testing +after_type line 2
+
+# Keep alive
++keep_alive Test_Mesh::AddNode-->1, 2

--- a/test/expected/Test.cxx
+++ b/test/expected/Test.cxx
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <pyOCCT_Common.hxx>
 #include <Test_Enum.h>
 #include <Test_Class.h>
+#include <Test_KeepAlive.h>
 
 PYBIND11_MODULE(Test, mod) {
 
@@ -58,6 +59,21 @@ cls_Test_SimpleClass.def("TestReturnPolicy3", (int & (Test_SimpleClass::*)()) &T
 // TYPEDEF: TAGGEDENUM
 
 // TYPEDEF: UNTAGGEDENUM
+
+// CLASS: TEST_NODE
+py::class_<Test_Node> cls_Test_Node(mod, "Test_Node", "None");
+
+// Constructors
+cls_Test_Node.def(py::init<>());
+
+// CLASS: TEST_MESH
+py::class_<Test_Mesh> cls_Test_Mesh(mod, "Test_Mesh", "None");
+
+// Constructors
+cls_Test_Mesh.def(py::init<>());
+
+// Methods
+cls_Test_Mesh.def("AddNode", (void (Test_Mesh::*)(const int, Test_Node *)) &Test_Mesh::AddNode, "None", py::arg("id"), py::arg("node"), py::keep_alive<1, 2>());
 
 
 }

--- a/test/include/Test_KeepAlive.h
+++ b/test/include/Test_KeepAlive.h
@@ -1,0 +1,19 @@
+
+class Test_Node
+{
+public:
+
+    Test_Node();
+
+};
+
+
+class Test_Mesh
+{
+public:
+
+    Test_Mesh();
+
+    // Dear SMESHd devs, do not use raw pointers like this...
+    void AddNode(const int id, Test_Node* node);
+};


### PR DESCRIPTION
Adds support for https://pybind11.readthedocs.io/en/stable/advanced/functions.html#keep-alive. 

Don't need to merge now. This is for smesh.  Cherry picked from #21 

The pybind arguments are confusing to keep track of so I was thinking of also making it use names? 

Eg:

- Instead of `-->0, 1` use `-->return_value, this` 
- Instead of `-->1, 2` use `-->this, arg[0]` 