### PR TITLE
Split modules into separate source files

### DIFF
--- a/test/all_includes.h
+++ b/test/all_includes.h
@@ -2,3 +2,4 @@
 #include <Test_Enum.h>
 #include <Test_KeepAlive.h>
 #include <Test_Template.h>
+#include <TestSplit_Module.h>

--- a/test/config.txt
+++ b/test/config.txt
@@ -23,3 +23,6 @@
 
 # Keep alive
 +keep_alive Test_Mesh::AddNode-->1, 2
+
+# Split modules
++split TestSplit

--- a/test/expected/TestSplit.cxx
+++ b/test/expected/TestSplit.cxx
@@ -1,0 +1,40 @@
+/*
+This file is part of pyOCCT which provides Python bindings to the OpenCASCADE
+geometry kernel.
+
+Copyright (C) 2016-2018  Laughlin Research, LLC
+Copyright (C) 2019-2020  Trevor Laughlin and the pyOCCT contributors
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#include <pyOCCT_Common.hxx>
+#include <TestSplit_Module.h>
+
+// Functions for split modules
+void bind_TestSplit_2(py::module&);
+
+PYBIND11_MODULE(TestSplit, mod) {
+
+
+// CLASS: TESTSPLIT_CLASSA
+py::class_<TestSplit_ClassA> cls_TestSplit_ClassA(mod, "TestSplit_ClassA", "Test content to split into different source files");
+
+// Constructors
+cls_TestSplit_ClassA.def(py::init<>());
+
+
+bind_TestSplit_2(mod);
+
+}

--- a/test/expected/TestSplit_2.cxx
+++ b/test/expected/TestSplit_2.cxx
@@ -1,0 +1,35 @@
+/*
+This file is part of pyOCCT which provides Python bindings to the OpenCASCADE
+geometry kernel.
+
+Copyright (C) 2016-2018  Laughlin Research, LLC
+Copyright (C) 2019-2020  Trevor Laughlin and the pyOCCT contributors
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#include <pyOCCT_Common.hxx>
+#include <TestSplit_Module.h>
+
+void bind_TestSplit_2(py::module &mod)
+{
+
+// CLASS: TESTSPLIT_CLASSB
+py::class_<TestSplit_ClassB> cls_TestSplit_ClassB(mod, "TestSplit_ClassB", "None");
+
+// Constructors
+cls_TestSplit_ClassB.def(py::init<>());
+
+
+}

--- a/test/include/TestSplit_Module.h
+++ b/test/include/TestSplit_Module.h
@@ -1,0 +1,17 @@
+/// Test content to split into different source files
+class TestSplit_ClassA
+{
+public:
+
+    TestSplit_ClassA();
+
+};
+
+
+class TestSplit_ClassB
+{
+public:
+
+    TestSplit_ClassB();
+
+};

--- a/test/test_pybinder.py
+++ b/test/test_pybinder.py
@@ -32,7 +32,7 @@ class TestBinder(unittest.TestCase):
         """
         Set up the tests by parsing the header.
         """
-        available_mods = {'Test'}
+        available_mods = {'Test', 'TestSplit'}
         inc = './include/'
         output_path = './output'
         gen = Generator(available_mods, inc)
@@ -49,6 +49,13 @@ class TestBinder(unittest.TestCase):
 
     def test_compare_output(self):
         for filename in ('Test.cxx', 'bind_Test_Template.hxx'):
+            with open(f'output/{filename}') as f1:
+                with open(f'expected/{filename}') as f2:
+                    for l1, l2 in zip(f1, f2):
+                        self.assertEqual(l1, l2)
+
+    def test_compare_split(self):
+        for filename in ('TestSplit.cxx', 'TestSplit_2.cxx'):
             with open(f'output/{filename}') as f1:
                 with open(f'expected/{filename}') as f2:
                     for l1, l2 in zip(f1, f2):


### PR DESCRIPTION
A new "+split" option in the configuration file will split the contents of a module into two files for now